### PR TITLE
Add `Ord` instance

### DIFF
--- a/src/Data/NanoID.hs
+++ b/src/Data/NanoID.hs
@@ -12,7 +12,7 @@ import           GHC.Generics
 import           Numeric.Natural
 import           System.Random.MWC
 
-newtype NanoID = NanoID { unNanoID :: C.ByteString } deriving (Eq,Generic)
+newtype NanoID = NanoID { unNanoID :: C.ByteString } deriving (Eq,Ord,Generic)
 
 newtype Alphabet = Alphabet { unAlphabet :: C.ByteString } deriving (Eq)
 


### PR DESCRIPTION
Enables NanoID to be used as a Map key.