### PR TITLE
Fix a typo in uppercase letters of the defaultAlphabet

### DIFF
--- a/src/Data/NanoID.hs
+++ b/src/Data/NanoID.hs
@@ -71,7 +71,7 @@ customNanoID a l g =
 
 -- | The default 'Alphabet', made of URL-friendly symbols.
 defaultAlphabet :: Alphabet
-defaultAlphabet = toAlphabet "ABCDEFGHIJKLMNOPKRSTUVWXYZ_1234567890-abcdefghijklmnopqrstuvwxyz"
+defaultAlphabet = toAlphabet "ABCDEFGHIJKLMNOPQRSTUVWXYZ_1234567890-abcdefghijklmnopqrstuvwxyz"
 
 -- * Some predefined 'Alphabet's, borrowed from https://github.com/CyberAP/nanoid-dictionary
 


### PR DESCRIPTION
I noticed that `K` is repeated, and `Q` is missing, so this is clearly a typo.